### PR TITLE
Support out_key_os_version

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Output messages with tag 'merged.**' has attributes like 'agent\_name', 'agent\_
       out_key_name ua_name
       out_key_category ua_category
       out_key_os ua_os
+      out_key_os_version ua_os_version
       out_key_version ua_version
       out_key_vendor ua_vendor
     </match>

--- a/fluent-plugin-woothee.gemspec
+++ b/fluent-plugin-woothee.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_development_dependency "rake"
+  gem.add_development_dependency "test-unit", "~> 3.0.2"
   gem.add_runtime_dependency "fluentd"
-  gem.add_runtime_dependency "woothee", ">= 0.2.4"
+  gem.add_runtime_dependency "woothee", ">= 1.0.0"
 end

--- a/lib/fluent/plugin/out_woothee.rb
+++ b/lib/fluent/plugin/out_woothee.rb
@@ -22,6 +22,7 @@ class Fluent::WootheeOutput < Fluent::Output
   config_param :out_key_name, :string, :default => 'agent_name'
   config_param :out_key_category, :string, :default => 'agent_category'
   config_param :out_key_os, :string, :default => 'agent_os'
+  config_param :out_key_os_version, :string, :default => nil # supress output
   config_param :out_key_version, :string, :default => nil # supress output
   config_param :out_key_vendor, :string, :default => nil # supress output
 
@@ -121,6 +122,7 @@ class Fluent::WootheeOutput < Fluent::Output
             @out_key_category => parsed[Woothee::ATTRIBUTE_CATEGORY].to_s,
             @out_key_os => parsed[Woothee::ATTRIBUTE_OS]
           })
+        record[@out_key_os_version] = parsed[Woothee::ATTRIBUTE_OS_VERSION] if @out_key_os_version
         record[@out_key_version] = parsed[Woothee::ATTRIBUTE_VERSION] if @out_key_version
         record[@out_key_vendor] = parsed[Woothee::ATTRIBUTE_VENDOR] if @out_key_vendor
       end

--- a/test/plugin/test_out_woothee.rb
+++ b/test/plugin/test_out_woothee.rb
@@ -28,6 +28,7 @@ merge_agent_info yes
 out_key_name ua_name
 out_key_category ua_category
 out_key_os ua_os
+out_key_os_version ua_os_version
 out_key_version ua_version
 out_key_vendor ua_vendor
 ]
@@ -39,6 +40,10 @@ key_name user_agent
 drop_categories crawler,misc
 tag selected
 ]
+
+  def setup
+    Fluent::Test.setup
+  end
 
   def create_driver(conf=CONFIG1,tag='test')
     Fluent::Test::OutputTestDriver.new(Fluent::WootheeOutput, tag).configure(conf)
@@ -85,6 +90,7 @@ tag selected
     assert_equal 'ua_name', d.instance.out_key_name
     assert_equal 'ua_category', d.instance.out_key_category
     assert_equal 'ua_os', d.instance.out_key_os
+    assert_equal 'ua_os_version', d.instance.out_key_os_version
     assert_equal 'ua_version', d.instance.out_key_version
     assert_equal 'ua_vendor', d.instance.out_key_vendor
 
@@ -250,11 +256,12 @@ tag selected
 
     # 'agent' => 'Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Win64; x64; Trident/6.0)'
     m = emits[0][2]
-    assert_equal 7, m.keys.size
+    assert_equal 8, m.keys.size
     assert_equal 0, m['value']
     assert_equal 'Internet Explorer', m['ua_name']
     assert_equal 'pc', m['ua_category']
     assert_equal 'Windows 8', m['ua_os']
+    assert_equal 'NT 6.2', m['ua_os_version']
     assert_equal 'Microsoft', m['ua_vendor']
     assert_equal '10.0', m['ua_version']
 
@@ -264,6 +271,7 @@ tag selected
     assert_equal 'Firefox', m['ua_name']
     assert_equal 'pc', m['ua_category']
     assert_equal 'Windows Vista', m['ua_os']
+    assert_equal 'NT 6.0', m['ua_os_version']
     assert_equal 'Mozilla', m['ua_vendor']
     assert_equal '9.0.1', m['ua_version']
 
@@ -273,6 +281,7 @@ tag selected
     assert_equal 'Firefox', m['ua_name']
     assert_equal 'pc', m['ua_category']
     assert_equal 'Linux', m['ua_os']
+    assert_equal 'UNKNOWN', m['ua_os_version']
     assert_equal 'Mozilla', m['ua_vendor']
     assert_equal '9.0.1', m['ua_version']
 
@@ -282,6 +291,7 @@ tag selected
     assert_equal 'Safari', m['ua_name']
     assert_equal 'smartphone', m['ua_category']
     assert_equal 'Android', m['ua_os']
+    assert_equal '3.1', m['ua_os_version']
     assert_equal 'Apple', m['ua_vendor']
     assert_equal '4.0', m['ua_version']
 
@@ -291,6 +301,7 @@ tag selected
     assert_equal 'docomo', m['ua_name']
     assert_equal 'mobilephone', m['ua_category']
     assert_equal 'docomo', m['ua_os']
+    assert_equal 'UNKNOWN', m['ua_os_version']
     assert_equal 'docomo', m['ua_vendor']
     assert_equal 'N505i', m['ua_version']
 
@@ -300,6 +311,7 @@ tag selected
     assert_equal 'PlayStation Vita', m['ua_name']
     assert_equal 'appliance', m['ua_category']
     assert_equal 'PlayStation Vita', m['ua_os']
+    assert_equal '1.51', m['ua_os_version']
     assert_equal 'Sony', m['ua_vendor']
     assert_equal 'UNKNOWN', m['ua_version']
   end


### PR DESCRIPTION
This pull request add support ["os_version" feature of Woothee 1.0+](https://github.com/woothee/woothee/commit/f941a9b73ab7dba1ebed5cc27d46273c484983f8)

And I also fix test that can run with fluent 0.12.x.